### PR TITLE
Browser Sync Fails on Windows

### DIFF
--- a/scripts/sb-watch.js
+++ b/scripts/sb-watch.js
@@ -29,6 +29,8 @@ _handleSCSS();
 
 function _processFile(filePath, watchEvent) {
     
+    filePath = filePath.replace(/\\/g, "/")
+    
     if (!READY) {
         if (filePath.match(/\.pug$/)) {
             if (!filePath.match(/includes/) && !filePath.match(/mixins/) && !filePath.match(/\/pug\/layouts\//)) {


### PR DESCRIPTION
On Windows machines, the browser sync fails due to filePath var using backslashes instead of forward. Used a string replace to correct. 